### PR TITLE
Set 'bap_anonymous_access_role' as read only role

### DIFF
--- a/opensearch_dashboards.yml
+++ b/opensearch_dashboards.yml
@@ -6,7 +6,9 @@ opensearch.password: "kibanaserver"
 opensearch.requestHeadersWhitelist: [ authorization,securitytenant ]
 
 opensearch_security.multitenancy.enabled: false
-opensearch_security.readonly_mode.roles: ["kibana_read_only"]
+opensearch_security.readonly_mode.roles:
+  - "kibana_read_only"
+  - "bap_anonymous_access_role"
 
 # Use this setting if you are running opensearch-dashboards without https
 opensearch_security.cookie.secure: false


### PR DESCRIPTION
Adding this role to the list of 'readonly_mode' roles, allows to have a real anonymous user which won't have access to some of the OpenSearch tools unless they log in.