### PR TITLE
Fix invalid default value for "server.host" parameter

### DIFF
--- a/opensearch_dashboards.yml
+++ b/opensearch_dashboards.yml
@@ -1,4 +1,4 @@
-server.host: "0"
+server.host: "0.0.0.0"
 opensearch.hosts: ["https://localhost:9200"]
 opensearch.ssl.verificationMode: none
 opensearch.username: "kibanaserver"
@@ -27,3 +27,5 @@ opensearchDashboards.branding:
 opensearch_security.basicauth.login.brandimage: "https://raw.githubusercontent.com/Bitergia/bitergia-analytics-opensearch-dashboards/master/assets/bitergia_login_logo.png"
 opensearch_security.basicauth.login.title: "Please login to Bitergia Analytics Dashboard."
 opensearch_security.basicauth.login.subtitle: "If you have forgotten your username or password, please contact the Bitergia staff."
+
+opensearch_security.auth.anonymous_auth_enabled: true


### PR DESCRIPTION
The 'opensearch_dashboards.yml' file contained an invalid value for the parameter 'server.host'. In older versions of OpenSearch and Kibana, this value was '0' but since OpenSearch 2.6, the new value has to be `0.0.0.0`.

As a workaround, while this PR is merged, users can define the environment variable `SERVER_HOST: '0.0.0.0'` to override the default wrong value.
