### PR TITLE
Install plugins one by one on Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,10 +24,10 @@ ENV PATH=/usr/share/opensearch-dashboards/bin:$PATH
 #
 
 # Install visualization plugins
-RUN opensearch-dashboards-plugin install "https://github.com/dlumbrer/kbn_radar/releases/download/osd-2.7.0/kbn_radar-7.10.0_2.7.0.zip" && \
-    opensearch-dashboards-plugin install "https://github.com/dlumbrer/kbn_network/releases/download/osd-2.7.0/kbn_network-7.10.0_2.7.0.zip" && \
-    opensearch-dashboards-plugin install "https://github.com/dlumbrer/kbn_dotplot/releases/download/osd-2.7.0/kbn_dotplot-7.10.0_2.7.0.zip" && \
-    opensearch-dashboards-plugin install "https:/github.com/dlumbrer/kbn_polar/releases/download/osd-2.7.0/kbn_polar-1.0.0_2.7.0.zip"
+RUN opensearch-dashboards-plugin install "https://github.com/dlumbrer/kbn_radar/releases/download/osd-2.7.0/kbn_radar-7.10.0_2.7.0.zip"
+RUN opensearch-dashboards-plugin install "https://github.com/dlumbrer/kbn_network/releases/download/osd-2.7.0/kbn_network-7.10.0_2.7.0.zip"
+RUN opensearch-dashboards-plugin install "https://github.com/dlumbrer/kbn_dotplot/releases/download/osd-2.7.0/kbn_dotplot-7.10.0_2.7.0.zip"
+RUN opensearch-dashboards-plugin install "https:/github.com/dlumbrer/kbn_polar/releases/download/osd-2.7.0/kbn_polar-1.0.0_2.7.0.zip"
 
 # Install enhanced table plugin
 RUN opensearch-dashboards-plugin install "https://github.com/fbaligand/kibana-enhanced-table/releases/download/v1.13.3/enhanced-table-1.13.3_osd-2.7.0.zip"


### PR DESCRIPTION
Installing the visualization plugins separately makes it easier to update their URLs on the release process.