### PR TITLE
Upgrade to OpenSearch Dashboards 2.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Bitergia
 # GPLv3 License
 
-FROM opensearchproject/opensearch-dashboards:2.7.0
+FROM opensearchproject/opensearch-dashboards:2.10.0
 
 LABEL maintainer="Santiago Dueñas <sduenas@bitergia.com>"
 LABEL org.opencontainers.image.title="Bitergia Analytics OpenSearch Dashboards"
@@ -30,7 +30,7 @@ RUN opensearch-dashboards-plugin install "https://github.com/dlumbrer/kbn_dotplo
 RUN opensearch-dashboards-plugin install "https:/github.com/dlumbrer/kbn_polar/releases/download/osd-2.7.0/kbn_polar-1.0.0_2.7.0.zip"
 
 # Install enhanced table plugin
-RUN opensearch-dashboards-plugin install "https://github.com/fbaligand/kibana-enhanced-table/releases/download/v1.13.3/enhanced-table-1.13.3_osd-2.7.0.zip"
+RUN opensearch-dashboards-plugin install "https://github.com/fbaligand/kibana-enhanced-table/releases/download/v1.13.3/enhanced-table-1.13.3_osd-2.10.0.zip"
 
 # Install Bitergia Analytics plugins
 RUN opensearch-dashboards-plugin install "https://github.com/bitergia-analytics/bitergia-analytics-plugin/releases/download/0.14.0/bitergia_analytics-0.14.0_2.7.0.zip"

--- a/releases/unreleased/update-to-opensearch-210.yml
+++ b/releases/unreleased/update-to-opensearch-210.yml
@@ -1,0 +1,7 @@
+---
+title: Upgrade to OpenSearch 2.10
+category: dependency
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  With this release, OpenSearch version has been upgraded to 2.10.


### PR DESCRIPTION
The Bitergia Analytics Plugins are not updated to the latest version because this will be done on the CI when plugins are compiled.