### PR TITLE
Upgrade to OpenSearch Dashboards 2.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Bitergia
 # GPLv3 License
 
-FROM opensearchproject/opensearch-dashboards:2.10.0
+FROM opensearchproject/opensearch-dashboards:2.11.1
 
 LABEL maintainer="Santiago Dueñas <sduenas@bitergia.com>"
 LABEL org.opencontainers.image.title="Bitergia Analytics OpenSearch Dashboards"
@@ -30,7 +30,7 @@ RUN opensearch-dashboards-plugin install https://github.com/bitergia-analytics/d
 RUN opensearch-dashboards-plugin install https://github.com/bitergia-analytics/polar-vis-plugin/releases/download/0.14.2/polar-vis-plugin-0.14.2_2.10.0.zip
 
 # Install enhanced table plugin
-RUN opensearch-dashboards-plugin install "https://github.com/fbaligand/kibana-enhanced-table/releases/download/v1.13.3/enhanced-table-1.13.3_osd-2.10.0.zip"
+RUN opensearch-dashboards-plugin install "https://github.com/fbaligand/kibana-enhanced-table/files/13727732/enhanced-table-1.14.0-alpha1_osd-2.11.1.zip"
 
 # Install Bitergia Analytics plugins
 RUN opensearch-dashboards-plugin install https://github.com/bitergia-analytics/bitergia-analytics-plugin/releases/download/0.14.2/bitergia-analytics-plugin-0.14.2_2.10.0.zip

--- a/releases/unreleased/upgrade-to-opensearch-dashboards-2111.yml
+++ b/releases/unreleased/upgrade-to-opensearch-dashboards-2111.yml
@@ -1,0 +1,9 @@
+---
+title: Upgrade to OpenSearch Dashboards 2.11.1
+category: added
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  OpenSearch Dashboard has been updated to 2.11.1
+  version to fix the problems found navigating
+  between dashboards.


### PR DESCRIPTION
On this new version, OSD fixes the error that showed an empty dashboards while navigating
between them.

Due to OSD 2.11.0 removed Angular support, the plugin 'enhanced-table' wasn't compatible anymore. The author of this plugin was created a new version but it's on alpha stages that we include within this image.