### PR TITLE
Upgrade OpenSearch Dashboards to version 3.7.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Bitergia
 # GPLv3 License
 
-FROM opensearchproject/opensearch-dashboards:3.2.0
+FROM opensearchproject/opensearch-dashboards:3.7.0
 
 LABEL maintainer="Santiago Dueñas <sduenas@bitergia.com>"
 LABEL org.opencontainers.image.title="Bitergia Analytics OpenSearch Dashboards"
@@ -30,7 +30,7 @@ RUN opensearch-dashboards-plugin install https://github.com/bitergia-analytics/d
 RUN opensearch-dashboards-plugin install https://github.com/bitergia-analytics/polar-vis-plugin/releases/download/0.39.0/polar-vis-plugin-0.39.0_3.2.0.zip
 
 # Install enhanced table plugin
-RUN opensearch-dashboards-plugin install "https://github.com/fbaligand/kibana-enhanced-table/releases/download/v1.14.0/enhanced-table-1.14.0_osd-3.2.0.zip"
+RUN opensearch-dashboards-plugin install "https://github.com/fbaligand/kibana-enhanced-table/releases/download/v1.14.0/enhanced-table-1.15.0_osd-3.7.0.zip"
 
 # Install Bitergia Analytics plugins
 RUN opensearch-dashboards-plugin install https://github.com/bitergia-analytics/bitergia-analytics-plugin/releases/download/0.39.0/bitergia-analytics-plugin-0.39.0_3.2.0.zip

--- a/releases/unreleased/opensearch-3-7-upgrade.yml
+++ b/releases/unreleased/opensearch-3-7-upgrade.yml
@@ -1,0 +1,9 @@
+---
+title: OpenSearch Dashboards 3.7 upgrade
+category: added
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Update base image for Bitergia Analytics OpenSearch Dashboards
+  to version 3.7.0. This release includes enhanced features for
+  data exploration and visualization.


### PR DESCRIPTION
Updated the base image for OpenSearch Dashboards to version 3.7.0, including all plugin versions. This release includes enhanced features such as Prometheus datasource integration, dashboard variables for template-driven dashboards, and improved visualization options.